### PR TITLE
Thorough graph service tests

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1,17 +1,25 @@
 package com.linkedin.metadata.graph;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.query.Filter;
 import com.linkedin.metadata.query.RelationshipDirection;
 import com.linkedin.metadata.query.RelationshipFilter;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
+import javax.annotation.Nullable;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 
 /**
@@ -21,8 +29,59 @@ import static org.testng.Assert.assertEquals;
  *
  * You can add implementation specific tests in derived classes, or add general tests
  * here and have all existing implementations tested in the same way.
+ *
+ * Note this base class does not test GraphService.addEdge explicitly. This method is tested
+ * indirectly by all tests via `getPopulatedGraphService` at the beginning of each test.
+ * The `getPopulatedGraphService` method calls `GraphService.addEdge` to populate the Graph.
+ * Feel free to add a test to your test implementation that calls `getPopulatedGraphService` and
+ * asserts the state of the graph in an implementation specific way.
  */
 abstract public class GraphServiceTestBase {
+
+  /**
+   * Some test dataset types.
+   */
+  protected static String datasetType = "dataset";
+  protected static String datasetVersionType = "datasetVersion";
+
+  /**
+   * Some test datasets.
+   */
+  protected static String datasetOneUrnString = "urn:li:" + datasetType + ":(urn:li:dataPlatform:type,SampleDatasetOne,PROD)";
+  protected static String datasetTwoUrnString = "urn:li:" + datasetType + ":(urn:li:dataPlatform:type,SampleDatasetTwo,PROD)";
+  protected static String datasetThreeUrnString = "urn:li:" + datasetVersionType + ":(urn:li:dataPlatform:type,SampleVersionedDataset,PROD,V1)";
+  protected static String datasetFourUrnString = "urn:li:" + datasetVersionType + ":(urn:li:dataPlatform:type,SampleVersionedDataset,PROD,V2)";
+
+  protected static Urn datasetOneUrn = createFromString(datasetOneUrnString);
+  protected static Urn datasetTwoUrn = createFromString(datasetTwoUrnString);
+  protected static Urn datasetThreeUrn = createFromString(datasetThreeUrnString);
+  protected static Urn datasetFourUrn = createFromString(datasetFourUrnString);
+
+  /**
+   * Some test relationships.
+   */
+  protected static String upstreamOf = "UpstreamOf";
+  protected static String nextVersionOf = "NextVersionOf";
+
+  /**
+   * Some relationship filters.
+   */
+  protected static RelationshipFilter incomingRelationships = createRelationshipFilter(RelationshipDirection.INCOMING);
+  protected static RelationshipFilter outgoingRelationships = createRelationshipFilter(RelationshipDirection.OUTGOING);
+  protected static RelationshipFilter undirectedRelationships = createRelationshipFilter(RelationshipDirection.UNDIRECTED);
+
+  /**
+   * Any source and destination type value.
+   */
+  protected static String anyType = "";
+
+  @Test
+  public void testStaticUrns() {
+    assertNotNull(datasetOneUrn);
+    assertNotNull(datasetTwoUrn);
+    assertNotNull(datasetThreeUrn);
+    assertNotNull(datasetFourUrn);
+  }
 
   /**
    * Provides the current GraphService instance to test. This is being called by the test method
@@ -42,114 +101,397 @@ abstract public class GraphServiceTestBase {
    */
   abstract protected void syncAfterWrite() throws Exception;
 
-  @Test
-  public void testAddEdge() throws Exception {
-    GraphService client = getGraphService();
+  /**
+   * Calls getGraphService to retrieve the test GraphService and populates it
+   * with edges via `GraphService.addEdge`.
+   *
+   * @return test GraphService
+   * @throws Exception on failure
+   */
+  protected GraphService getPopulatedGraphService() throws Exception {
+    GraphService service = getGraphService();
 
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        "DownstreamOf");
+    List<Edge> edges = Arrays.asList(
+            new Edge(datasetOneUrn, datasetTwoUrn, upstreamOf),
+            new Edge(datasetTwoUrn, datasetThreeUrn, upstreamOf),
+            new Edge(datasetTwoUrn, datasetFourUrn, upstreamOf),
+            new Edge(datasetFourUrn, datasetThreeUrn, nextVersionOf)
+    );
 
-    client.addEdge(edge1);
+    edges.forEach(service::addEdge);
     syncAfterWrite();
 
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.OUTGOING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+    return service;
+  }
 
-    List<String> relatedUrns = client.findRelatedUrns(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10);
+  protected static RelationshipFilter createRelationshipFilter(RelationshipDirection direction) {
+    return createRelationshipFilter(EMPTY_FILTER, direction);
+  }
 
-    assertEquals(relatedUrns.size(), 1);
+  protected static RelationshipFilter createRelationshipFilter(@Nonnull Filter filter,
+                                                               @Nonnull RelationshipDirection direction) {
+    return new RelationshipFilter()
+            .setCriteria(filter.getCriteria())
+            .setDirection(direction);
+  }
+
+  protected static @Nullable
+  Urn createFromString(@Nonnull String rawUrn) {
+    try {
+      return Urn.createFromString(rawUrn);
+    } catch (URISyntaxException e) {
+      return null;
+    }
+  }
+
+  protected static <T> void assertEqualsNoOrder(List<T> actual, List<T> expected) {
+    // TODO: there should be no duplicates
+    //Assert.assertEqualsNoOrder(actual.toArray(), expected.toArray());
+    assertEquals(new HashSet<>(actual), new HashSet<>(expected));
+  }
+
+  @DataProvider(name="FindRelatedUrnsSourceEntityFilterTests")
+  public Object[][] getFindRelatedUrnsSourceEntityFilterTests() {
+    return new Object[][] {
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    outgoingRelationships,
+                    Arrays.asList(datasetThreeUrnString, datasetFourUrnString)
+            },
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    incomingRelationships,
+                    Arrays.asList(datasetOneUrnString)
+            },
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    undirectedRelationships,
+                    Arrays.asList(datasetOneUrnString, datasetThreeUrnString, datasetFourUrnString)
+            }
+    };
+  }
+
+  @Test(dataProvider="FindRelatedUrnsSourceEntityFilterTests")
+  public void testFindRelatedUrnsSourceEntityFilter(Filter sourceEntityFilter,
+                                                    RelationshipFilter relationships,
+                                                    List<String> expectedUrnStrings) throws Exception {
+    doTestFindRelatedUrns(
+            sourceEntityFilter,
+            EMPTY_FILTER,
+            relationships,
+            expectedUrnStrings.toArray(new String[0])
+    );
+  }
+
+  @DataProvider(name="FindRelatedUrnsDestinationEntityFilterTests")
+  public Object[][] getFindRelatedUrnsDestinationEntityFilterTests() {
+    return new Object[][] {
+            new Object[] {
+                    newFilter("urn", datasetOneUrnString),
+                    outgoingRelationships,
+                    Arrays.asList()
+            },
+            new Object[] {
+                    newFilter("urn", datasetOneUrnString),
+                    incomingRelationships,
+                    Arrays.asList(datasetOneUrnString)
+            },
+            new Object[] {
+                    newFilter("urn", datasetOneUrnString),
+                    undirectedRelationships,
+                    Arrays.asList(datasetOneUrnString)
+            }
+    };
+  }
+
+  @Test(dataProvider="FindRelatedUrnsDestinationEntityFilterTests")
+  public void testFindRelatedUrnsDestinationEntityFilter(Filter destinationEntityFilter,
+                                                         RelationshipFilter relationships,
+                                                         List<String> expectedUrnStrings) throws Exception {
+    doTestFindRelatedUrns(
+            EMPTY_FILTER,
+            destinationEntityFilter,
+            relationships,
+            expectedUrnStrings.toArray(new String[0])
+    );
+  }
+
+  private void doTestFindRelatedUrns(
+          Filter sourceEntityFilter,
+          Filter destinationEntityFilter,
+          RelationshipFilter relationshipFilter,
+          String... expectedUrnStrings
+  ) throws Exception {
+    doTestFindRelatedUrns(
+            sourceEntityFilter, destinationEntityFilter,
+            Arrays.asList(upstreamOf), relationshipFilter,
+            expectedUrnStrings
+    );
+  }
+
+  private void doTestFindRelatedUrns(
+          final Filter sourceEntityFilter,
+          final Filter destinationEntityFilter,
+          List<String> relationshipTypes,
+          final RelationshipFilter relationshipFilter,
+          String... expectedUrnStrings
+  ) throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    List<String> relatedUrns = service.findRelatedUrns(
+            anyType, sourceEntityFilter,
+            anyType, destinationEntityFilter,
+            relationshipTypes, relationshipFilter,
+            0, 10
+    );
+
+    assertEqualsNoOrder(relatedUrns, Arrays.asList(expectedUrnStrings));
+  }
+
+  @DataProvider(name="FindRelatedUrnsSourceTypeTests")
+  public Object[][] getFindRelatedUrnsSourceTypeTests() {
+    return new Object[][]{
+            new Object[]{datasetType, outgoingRelationships, Arrays.asList(datasetTwoUrnString, datasetThreeUrnString, datasetFourUrnString)},
+            new Object[]{datasetVersionType, outgoingRelationships, Arrays.asList()},
+
+            new Object[]{datasetType, incomingRelationships, Arrays.asList(datasetOneUrnString, datasetTwoUrnString)},
+            new Object[]{datasetVersionType, incomingRelationships, Arrays.asList(datasetTwoUrnString)},
+
+            new Object[]{datasetType, undirectedRelationships, Arrays.asList(datasetOneUrnString, datasetTwoUrnString)},
+            new Object[]{datasetVersionType, undirectedRelationships, Arrays.asList(datasetThreeUrnString, datasetFourUrnString)}
+    };
+  }
+
+  @Test(dataProvider="FindRelatedUrnsSourceTypeTests")
+  public void testFindRelatedUrnsSourceType(String datasetType,
+                                            RelationshipFilter relationships,
+                                            List<String> expectedUrnStrings) throws Exception {
+    doTestFindRelatedUrns(
+            datasetType,
+            anyType,
+            relationships,
+            expectedUrnStrings.toArray(new String[0])
+    );
+  }
+
+  @DataProvider(name="FindRelatedUrnsDestinationTypeTests")
+  public Object[][] getFindRelatedUrnsDestinationTypeTests() {
+    return new Object[][] {
+            new Object[] { datasetType, outgoingRelationships, Arrays.asList(datasetTwoUrnString) },
+            new Object[] { datasetVersionType, outgoingRelationships, Arrays.asList(datasetThreeUrnString, datasetFourUrnString) },
+
+            new Object[] { datasetType, incomingRelationships, Arrays.asList(datasetOneUrnString, datasetTwoUrnString) },
+            new Object[] { datasetVersionType, incomingRelationships, Arrays.asList() },
+
+            new Object[] { datasetType, undirectedRelationships, Arrays.asList(datasetOneUrnString, datasetTwoUrnString) },
+            new Object[] { datasetVersionType, undirectedRelationships, Arrays.asList(datasetThreeUrnString, datasetFourUrnString) }
+    };
+  }
+
+  @Test(dataProvider="FindRelatedUrnsDestinationTypeTests")
+  public void testFindRelatedUrnsDestinationType(String datasetType,
+                                                 RelationshipFilter relationships,
+                                                 List<String> expectedUrnStrings) throws Exception {
+    doTestFindRelatedUrns(
+            anyType,
+            datasetType,
+            relationships,
+            expectedUrnStrings.toArray(new String[0])
+    );
+  }
+
+  private void doTestFindRelatedUrns(
+          final String sourceType,
+          final String destinationType,
+          final RelationshipFilter relationshipFilter,
+          String... expectedUrnStrings
+  ) throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    List<String> relatedUrns = service.findRelatedUrns(
+            sourceType, EMPTY_FILTER,
+            destinationType, EMPTY_FILTER,
+            Arrays.asList(upstreamOf), relationshipFilter,
+            0, 10
+    );
+
+    assertEqualsNoOrder(relatedUrns, Arrays.asList(expectedUrnStrings));
   }
 
   @Test
-  public void testAddEdgeReverse() throws Exception {
-    GraphService client = getGraphService();
+  public void testFindRelatedUrnsOffsetAndCount() throws Exception {
+    GraphService service = getPopulatedGraphService();
 
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "DownstreamOf");
+    List<String> firstRelatedUrn = service.findRelatedUrns(
+            anyType, newFilter("urn", datasetTwoUrnString),
+            anyType, EMPTY_FILTER,
+            Arrays.asList(upstreamOf), outgoingRelationships,
+            0, 1
+    );
 
-    client.addEdge(edge1);
+    Assert.assertEquals(firstRelatedUrn.size(), 1);
+    Assert.assertTrue(firstRelatedUrn.contains(datasetThreeUrnString) || firstRelatedUrn.contains(datasetFourUrnString));
+
+    List<String> secondRelatedUrn = service.findRelatedUrns(
+            anyType, newFilter("urn", datasetTwoUrnString),
+            anyType, EMPTY_FILTER,
+            Arrays.asList(upstreamOf), outgoingRelationships,
+            1, 1
+    );
+
+    Assert.assertEquals(secondRelatedUrn.size(), 1);
+    Assert.assertTrue(secondRelatedUrn.contains(datasetThreeUrnString) || secondRelatedUrn.contains(datasetFourUrnString));
+    Assert.assertNotEquals(firstRelatedUrn.get(0), secondRelatedUrn.get(0));
+  }
+
+  @DataProvider(name="RemoveEdgesFromNodeTests")
+  public Object[][] getRemoveEdgesFromNodeTests() {
+    return new Object[][] {
+            new Object[] {
+                    datasetTwoUrn,
+                    outgoingRelationships,
+                    Arrays.asList(datasetOneUrnString, datasetThreeUrnString, datasetFourUrnString),
+                    Arrays.asList(datasetOneUrnString)
+            },
+            new Object[] {
+                    datasetTwoUrn,
+                    incomingRelationships,
+                    Arrays.asList(datasetOneUrnString, datasetThreeUrnString, datasetFourUrnString),
+                    Arrays.asList(datasetThreeUrnString, datasetFourUrnString)
+            },
+            new Object[] {
+                    datasetTwoUrn,
+                    undirectedRelationships,
+                    Arrays.asList(datasetOneUrnString, datasetThreeUrnString, datasetFourUrnString),
+                    Arrays.asList()
+            }
+    };
+  }
+
+  @Test(dataProvider="RemoveEdgesFromNodeTests")
+  public void testRemoveEdgesFromNode(@Nonnull Urn nodeToRemoveFrom,
+                                      @Nonnull RelationshipFilter relationshipFilter,
+                                      List<String> expectedRelatedUrnsBeforeRemove,
+                                      List<String> expectedRelatedUrnsAfterRemove) throws Exception {
+    GraphService service = getPopulatedGraphService();
+    List<String> edgeTypes = Arrays.asList(upstreamOf);
+
+    List<String> actualRelatedUrnsBeforeRemove = service.findRelatedUrns(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            edgeTypes, undirectedRelationships,
+            0, 10);
+    assertEqualsNoOrder(actualRelatedUrnsBeforeRemove, expectedRelatedUrnsBeforeRemove);
+
+    service.removeEdgesFromNode(
+            nodeToRemoveFrom,
+            edgeTypes,
+            relationshipFilter
+    );
     syncAfterWrite();
 
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
-
-    List<String> relatedUrns = client.findRelatedUrns(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10);
-
-    assertEquals(relatedUrns.size(), 1);
+    List<String> actualRelatedUrnsAfterRemove = service.findRelatedUrns(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            edgeTypes, undirectedRelationships,
+            0, 10);
+    assertEqualsNoOrder(actualRelatedUrnsAfterRemove, expectedRelatedUrnsAfterRemove);
   }
 
   @Test
-  public void testRemoveEdgesFromNode() throws Exception {
-    GraphService client = getGraphService();
+  public void testRemoveNode() throws Exception {
+    GraphService service = getPopulatedGraphService();
 
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "DownstreamOf");
+    // assert the initial graph: check all nodes related to upstreamOf and nextVersionOf edges
+    assertEqualsNoOrder(
+            service.findRelatedUrns(
+                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(upstreamOf), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(datasetOneUrnString, datasetTwoUrnString, datasetThreeUrnString, datasetFourUrnString)
+    );
+    assertEqualsNoOrder(
+            service.findRelatedUrns(
+                    datasetVersionType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(nextVersionOf), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(datasetThreeUrnString, datasetFourUrnString)
+    );
 
-    client.addEdge(edge1);
+    service.removeNode(datasetTwoUrn);
     syncAfterWrite();
 
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
-
-    List<String> relatedUrns = client.findRelatedUrns(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10);
-
-    assertEquals(relatedUrns.size(), 1);
-
-    client.removeEdgesFromNode(Urn.createFromString(
-        "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        edgeTypes,
-        relationshipFilter);
-    syncAfterWrite();
-
-    List<String> relatedUrnsPostDelete = client.findRelatedUrns(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10);
-
-    assertEquals(relatedUrnsPostDelete.size(), 0);
+    // assert the modified graph: check all nodes related to upstreamOf and nextVersionOf edges again
+    assertEqualsNoOrder(
+            service.findRelatedUrns(
+                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(upstreamOf), undirectedRelationships,
+                    0, 10
+            ),
+            Collections.emptyList()
+    );
+    assertEqualsNoOrder(
+            service.findRelatedUrns(
+                    datasetVersionType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(nextVersionOf), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(datasetThreeUrnString, datasetFourUrnString)
+    );
   }
+
+  @Test
+  public void testClear() throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    // assert the initial graph: check all nodes related to upstreamOf and nextVersionOf edges
+    assertEqualsNoOrder(
+            service.findRelatedUrns(
+                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(upstreamOf), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(datasetOneUrnString, datasetTwoUrnString, datasetThreeUrnString, datasetFourUrnString)
+    );
+    assertEqualsNoOrder(
+            service.findRelatedUrns(
+                    datasetVersionType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(nextVersionOf), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(datasetThreeUrnString, datasetFourUrnString)
+    );
+
+    service.clear();
+    syncAfterWrite();
+
+    // assert the modified graph: check all nodes related to upstreamOf and nextVersionOf edges again
+    assertEqualsNoOrder(
+            service.findRelatedUrns(
+                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(upstreamOf), undirectedRelationships,
+                    0, 10
+            ),
+            Collections.emptyList()
+    );
+    assertEqualsNoOrder(
+            service.findRelatedUrns(
+                    datasetVersionType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(nextVersionOf), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList()
+    );
+  }
+
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -81,8 +81,8 @@ abstract public class GraphServiceTestBase {
   /**
    * Some relationship filters.
    */
-  protected static RelationshipFilter incomingRelationships = createRelationshipFilter(RelationshipDirection.INCOMING);
   protected static RelationshipFilter outgoingRelationships = createRelationshipFilter(RelationshipDirection.OUTGOING);
+  protected static RelationshipFilter incomingRelationships = createRelationshipFilter(RelationshipDirection.INCOMING);
   protected static RelationshipFilter undirectedRelationships = createRelationshipFilter(RelationshipDirection.UNDIRECTED);
 
   /**
@@ -170,7 +170,6 @@ abstract public class GraphServiceTestBase {
   }
 
   protected static <T> void assertEqualsAsSets(List<T> actual, List<T> expected) {
-    // TODO: there should be no duplicates
     assertEquals(new HashSet<>(actual), new HashSet<>(expected));
   }
 
@@ -348,6 +347,25 @@ abstract public class GraphServiceTestBase {
   @DataProvider(name = "FindRelatedUrnsSourceTypeTests")
   public Object[][] getFindRelatedUrnsSourceTypeTests() {
     return new Object[][]{
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(datasetOneUrnString, datasetTwoUrnString)
+            },
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(datasetTwoUrnString, datasetThreeUrnString, datasetFourUrnString)
+            },
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(datasetOneUrnString, datasetTwoUrnString, datasetThreeUrnString, datasetFourUrnString)
+            },
+
             new Object[]{
                     datasetType,
                     Arrays.asList(downstreamOf),
@@ -424,6 +442,25 @@ abstract public class GraphServiceTestBase {
   @DataProvider(name = "FindRelatedUrnsDestinationTypeTests")
   public Object[][] getFindRelatedUrnsDestinationTypeTests() {
     return new Object[][] {
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(datasetOneUrnString, datasetTwoUrnString)
+            },
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(datasetTwoUrnString, datasetThreeUrnString, datasetFourUrnString)
+            },
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(datasetOneUrnString, datasetTwoUrnString, datasetThreeUrnString, datasetFourUrnString)
+            },
+
             new Object[] {
                     datasetType,
                     Arrays.asList(downstreamOf),

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -11,15 +11,20 @@ import org.testng.annotations.Test;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
-import static org.testng.Assert.*;
-
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Base class for testing any GraphService implementation.
@@ -165,7 +170,7 @@ abstract public class GraphServiceTestBase {
     assertEquals(new HashSet<>(actual), new HashSet<>(expected));
   }
 
-  @DataProvider(name="FindRelatedUrnsSourceEntityFilterTests")
+  @DataProvider(name = "FindRelatedUrnsSourceEntityFilterTests")
   public Object[][] getFindRelatedUrnsSourceEntityFilterTests() {
     return new Object[][] {
             new Object[] {
@@ -227,7 +232,7 @@ abstract public class GraphServiceTestBase {
     };
   }
 
-  @Test(dataProvider="FindRelatedUrnsSourceEntityFilterTests")
+  @Test(dataProvider = "FindRelatedUrnsSourceEntityFilterTests")
   public void testFindRelatedUrnsSourceEntityFilter(Filter sourceEntityFilter,
                                                     List<String> relationshipTypes,
                                                     RelationshipFilter relationships,
@@ -241,7 +246,7 @@ abstract public class GraphServiceTestBase {
     );
   }
 
-  @DataProvider(name="FindRelatedUrnsDestinationEntityFilterTests")
+  @DataProvider(name = "FindRelatedUrnsDestinationEntityFilterTests")
   public Object[][] getFindRelatedUrnsDestinationEntityFilterTests() {
     return new Object[][] {
             new Object[] {
@@ -303,7 +308,7 @@ abstract public class GraphServiceTestBase {
     };
   }
 
-  @Test(dataProvider="FindRelatedUrnsDestinationEntityFilterTests")
+  @Test(dataProvider = "FindRelatedUrnsDestinationEntityFilterTests")
   public void testFindRelatedUrnsDestinationEntityFilter(Filter destinationEntityFilter,
                                                          List<String> relationshipTypes,
                                                          RelationshipFilter relationships,
@@ -336,7 +341,7 @@ abstract public class GraphServiceTestBase {
     assertEqualsAsSets(relatedUrns, Arrays.asList(expectedUrnStrings));
   }
 
-  @DataProvider(name="FindRelatedUrnsSourceTypeTests")
+  @DataProvider(name = "FindRelatedUrnsSourceTypeTests")
   public Object[][] getFindRelatedUrnsSourceTypeTests() {
     return new Object[][]{
             new Object[]{
@@ -398,7 +403,7 @@ abstract public class GraphServiceTestBase {
     };
   }
 
-  @Test(dataProvider="FindRelatedUrnsSourceTypeTests")
+  @Test(dataProvider = "FindRelatedUrnsSourceTypeTests")
   public void testFindRelatedUrnsSourceType(String datasetType,
                                             List<String> relationshipTypes,
                                             RelationshipFilter relationships,
@@ -412,7 +417,7 @@ abstract public class GraphServiceTestBase {
     );
   }
 
-  @DataProvider(name="FindRelatedUrnsDestinationTypeTests")
+  @DataProvider(name = "FindRelatedUrnsDestinationTypeTests")
   public Object[][] getFindRelatedUrnsDestinationTypeTests() {
     return new Object[][] {
             new Object[] {
@@ -474,7 +479,7 @@ abstract public class GraphServiceTestBase {
     };
   }
 
-  @Test(dataProvider="FindRelatedUrnsDestinationTypeTests")
+  @Test(dataProvider = "FindRelatedUrnsDestinationTypeTests")
   public void testFindRelatedUrnsDestinationType(String datasetType,
                                                  List<String> relationshipTypes,
                                                  RelationshipFilter relationships,
@@ -533,7 +538,7 @@ abstract public class GraphServiceTestBase {
     Assert.assertEquals(individualRelatedUrn, allRelatedUrn);
   }
 
-  @DataProvider(name="RemoveEdgesFromNodeTests")
+  @DataProvider(name = "RemoveEdgesFromNodeTests")
   public Object[][] getRemoveEdgesFromNodeTests() {
     return new Object[][] {
             new Object[] {
@@ -560,7 +565,7 @@ abstract public class GraphServiceTestBase {
     };
   }
 
-  @Test(dataProvider="RemoveEdgesFromNodeTests")
+  @Test(dataProvider = "RemoveEdgesFromNodeTests")
   public void testRemoveEdgesFromNode(@Nonnull Urn nodeToRemoveFrom,
                                       @Nonnull List<String> relationTypes,
                                       @Nonnull RelationshipFilter relationshipFilter,


### PR DESCRIPTION
Adds a more complex test graph and tests all `GraphService` methods thoroughly. In the current implementation, tests depend on the order of test execution, as they share the state of the test store.

As the interface is not documented, a couple of questions on which results to expect from the given graph arose:
- Is it expected that `findRelatedUrns` returns duplicates, i.e. Urns may occur multiple times?
- Should `findRelatedUrns` with `RelationshipDirection.UNDIRECTED` return the union of `RelationshipDirection.OUTCOMING` and `RelationshipDirection.INGOING`?
- The `sourceType` and `destinationType` of `findRelatedUrns` are explicitly `@Nullable`, does `null` represent any type?
- From current tests it looks like `""` is also interpreted as any type, shouldn't this be deprecated in favour of `null` and disallow empty types? When a type is given (non-null), it should be a useful type string.
- Should `removeEdgesFromNode` with `RelationshipDirection.UNDIRECTED` be equivalent to calling it with `RelationshipDirection.OUTCOMING` and `RelationshipDirection.INGOING`?
- Is it expected to always have at least one relationship type given when calling `findRelatedUrns` and `removeEdgesFromNode`? Is an implementation allowed to enforce this limitation?