### PR TITLE
Move general createRelationshipFilter from Neo4jUtil to QueryUtils

### DIFF
--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dataset/DownstreamLineageResource.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dataset/DownstreamLineageResource.java
@@ -33,7 +33,6 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import static com.linkedin.metadata.dao.Neo4jUtil.*;
 import static com.linkedin.metadata.dao.utils.QueryUtils.*;
 
 
@@ -75,7 +74,7 @@ public final class DownstreamLineageResource extends SimpleResourceTemplate<Down
           "dataset",
           EMPTY_FILTER,
           ImmutableList.of("DownstreamOf"),
-          createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
+          newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
           0,
           MAX_DOWNSTREAM_CNT
       ).stream().map(urnStr -> {

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/lineage/Lineage.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/lineage/Lineage.java
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.linkedin.metadata.dao.Neo4jUtil.createRelationshipFilter;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+import static com.linkedin.metadata.dao.utils.QueryUtils.newRelationshipFilter;
 
 
 /**
@@ -74,7 +74,7 @@ public final class Lineage extends SimpleResourceTemplate<EntityRelationships> {
         return
             _graphService.findRelatedUrns("", newFilter("urn", rawUrn),
                 "", EMPTY_FILTER,
-                relationshipTypes, createRelationshipFilter(EMPTY_FILTER, direction),
+                relationshipTypes, newRelationshipFilter(EMPTY_FILTER, direction),
                 0, MAX_DOWNSTREAM_CNT)
                 .stream().map(
                 rawRelatedUrn -> {

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/lineage/Relationships.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/lineage/Relationships.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.linkedin.metadata.dao.Neo4jUtil.*;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+import static com.linkedin.metadata.dao.utils.QueryUtils.newRelationshipFilter;
 
 
 /**
@@ -51,7 +51,7 @@ public final class Relationships extends SimpleResourceTemplate<EntityRelationsh
         return
                 _graphService.findRelatedUrns("", newFilter("urn", rawUrn),
                         "", EMPTY_FILTER,
-                        relationshipTypes, createRelationshipFilter(EMPTY_FILTER, direction),
+                        relationshipTypes, newRelationshipFilter(EMPTY_FILTER, direction),
                         0, MAX_DOWNSTREAM_CNT)
                 .stream().map(
                         rawRelatedUrn -> {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataAuditEventsProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataAuditEventsProcessor.java
@@ -51,7 +51,7 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-import static com.linkedin.metadata.dao.Neo4jUtil.createRelationshipFilter;
+import static com.linkedin.metadata.dao.utils.QueryUtils.newRelationshipFilter;
 
 
 @Slf4j
@@ -213,7 +213,7 @@ public class MetadataAuditEventsProcessor {
     if (edgesToAdd.size() > 0) {
       new Thread(() -> {
         _graphService.removeEdgesFromNode(sourceUrn, new ArrayList<>(relationshipTypesBeingAdded),
-            createRelationshipFilter(new Filter().setCriteria(new CriterionArray()), RelationshipDirection.OUTGOING));
+            newRelationshipFilter(new Filter().setCriteria(new CriterionArray()), RelationshipDirection.OUTGOING));
         if (!delete) {
           edgesToAdd.forEach(edge -> _graphService.addEdge(edge));
         } else if (deleteEntity) {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
@@ -49,7 +49,7 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-import static com.linkedin.metadata.dao.Neo4jUtil.createRelationshipFilter;
+import static com.linkedin.metadata.dao.utils.QueryUtils.newRelationshipFilter;
 
 
 @Slf4j
@@ -151,7 +151,7 @@ public class MetadataChangeLogProcessor {
     if (edgesToAdd.size() > 0) {
       new Thread(() -> {
         _graphService.removeEdgesFromNode(urn, new ArrayList<>(relationshipTypesBeingAdded),
-            createRelationshipFilter(new Filter().setCriteria(new CriterionArray()), RelationshipDirection.OUTGOING));
+            newRelationshipFilter(new Filter().setCriteria(new CriterionArray()), RelationshipDirection.OUTGOING));
         edgesToAdd.forEach(edge -> _graphService.addEdge(edge));
       }).start();
     }


### PR DESCRIPTION
These methods are not Neo4j-specific so they can be moved out of Neo4Util. This removes Neo4jUtil imports from classes, that have no other reference to neo4j.